### PR TITLE
Refactor CreateProjectEnvironment method signature

### DIFF
--- a/src/ADOGenerator/Services/ProjectService.cs
+++ b/src/ADOGenerator/Services/ProjectService.cs
@@ -147,7 +147,7 @@ namespace ADOGenerator.Services
         public string[] CreateProjectEnvironment(Project model)
         {
             string pat = model.accessToken;
-            string templateUsed = model.selectedTemplateFolder;
+            templateUsed = model.selectedTemplateFolder;
             string accountName = model.accountName;
             //define versions to be use
             string projectCreationVersion = _configuration["AppSettings:ProjectCreationVersion"] ?? string.Empty;


### PR DESCRIPTION
This pull request includes a minor change to the `CreateProjectEnvironment` method in the `ProjectService` class. The change involves removing the redundant declaration of the `templateUsed` variable.

* [`src/ADOGenerator/Services/ProjectService.cs`](diffhunk://#diff-381a959bf359ea5015c2ab0d877b21f03078a8a9c40d16fb218a35b6bccb5de2L150-R150): Removed the redundant declaration of the `templateUsed` variable in the `CreateProjectEnvironment` method.